### PR TITLE
updated doc update github action with permissions needs

### DIFF
--- a/.github/workflows/receive_documentation_update.yml
+++ b/.github/workflows/receive_documentation_update.yml
@@ -9,6 +9,8 @@ jobs:
     container:
       image: docker://pandoc/latex:2.9
       options: --entrypoint=bash
+    permissions:
+      contents: write
     steps:
       - name: get actions tools
         run: |


### PR DESCRIPTION
the auto-commit image used was updated earlier this year requiring permissions to be added for the default GITHUB_TOKEN in order for the image to be able to work. This adds those in